### PR TITLE
🐛 Fix `mbtf` bugs

### DIFF
--- a/cmd/mbtf/main.go
+++ b/cmd/mbtf/main.go
@@ -36,6 +36,7 @@ func makeMetabaseClient(ctx context.Context, config metabaseConfig) (*metabase.C
 func setUpDatabases(ctx context.Context, config databasesConfig, ic importer.ImportContext) error {
 	definitions := make([]importer.ExistingDatabaseDefinition, 0, len(config.Mapping))
 	for _, d := range config.Mapping {
+		d := d
 		var id *int
 		var name *string
 
@@ -65,6 +66,7 @@ func setUpDatabases(ctx context.Context, config databasesConfig, ic importer.Imp
 func setUpCollections(ctx context.Context, config collectionsConfig, ic importer.ImportContext) error {
 	definitions := make([]importer.ExistingCollectionDefinition, 0, len(config.Mapping))
 	for _, d := range config.Mapping {
+		d := d
 		var id *string
 		var name *string
 

--- a/internal/importer/collection.go
+++ b/internal/importer/collection.go
@@ -88,7 +88,7 @@ func (ic *ImportContext) ImportCollectionsFromDefinitions(ctx context.Context, e
 
 		_, exists := ic.collections[collectionId]
 		if exists {
-			return fmt.Errorf("collection %s has already been imported", collection.Id)
+			return fmt.Errorf("collection %s has already been imported", collectionId)
 		}
 
 		ic.collections[collectionId] = importedCollection{


### PR DESCRIPTION
### 📝 Description of the PR

This PR fixes a bug when importing databases and collections in the `mbtf` configuration, due to [for loop semantics](https://github.com/golang/go/discussions/56010).

### 🐙 Related GitHub issue(s)

N/A

### 🕰️ Commits

- 🐛 Fix use of per-loop variable address
- 🐛 Fix use of collection ID in error message