### PR TITLE
🐛 mbtf: Fix error not being returned

### DIFF
--- a/cmd/mbtf/main.go
+++ b/cmd/mbtf/main.go
@@ -103,7 +103,7 @@ func runImport() error {
 
 	client, err := makeMetabaseClient(ctx, config.Metabase)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	ic := importer.NewImportContext(*client)


### PR DESCRIPTION
### 📝 Description of the PR

The title says it all. This would cause the `mbtf` tool to return with a `0` exit code and nothing logged when the Metabase client couldn't be created.

### 🐙 Related GitHub issue(s)

N/A

### 🕰️ Commits

- 🐛 Fix error not being returned