### PR TITLE
🔖 Prepare v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.4.0 (2024-01-31)
+
 BREAKING CHANGES:
 
 - Support Metabase v\*.48, and drop support for earlier versions. Make sure dashboard definitions follow the new schema (e.g. cards' `size{X|Y}` become `size_{x|y}`).

--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ For how to use the provider in a Terraform project, please refer to the [Terrafo
 Unfortunately, this provider relies on the Metabase API which is [subject to breaking changes and not versioned](https://www.metabase.com/docs/latest/api-documentation#about-the-metabase-api). This makes it hard for this provider to keep up with Metabase versions, apologies for that. Here is a table that summarizes supported Metabase versions:
 
 | Provider version \ Metabase version | .44 | .45 | .46 | .47 | .48 |
-| ----------------------------------- | --- | --- | --- | --- | --- |
-| 0.1                                 | ✅  | ❌  | ❌  | ❌  | ❌  |
-| 0.2                                 | ✅  | ❌  | ❌  | ❌  | ❌  |
-| 0.3                                 | ✅  | ❌  | ❌  | ❌  | ❌  |
+| ----------------------------------: | :-: | :-: | :-: | :-: | :-: |
+|                                 0.1 | ✅  | ❌  | ❌  | ❌  | ❌  |
+|                                 0.2 | ✅  | ❌  | ❌  | ❌  | ❌  |
+|                                 0.3 | ✅  | ❌  | ❌  | ❌  | ❌  |
+|                                 0.4 | ❌  | ❌  | ❌  | ❌  | ✅  |
 
 ## 🔨 `mbtf` importer tool
 


### PR DESCRIPTION
### 📝 Description of the PR

BREAKING CHANGES:

- Support Metabase v\*.48, and drop support for earlier versions. Make sure dashboard definitions follow the new schema (e.g. cards' `size{X|Y}` become `size_{x|y}`).
- Remove the `color` attribute on the `metabase_collection` resource.
- Remove the `cards_ids` attribute on the `metabase_dashboard` resource.

### 🐙 Related GitHub issue(s)

N/A

### 🕰️ Commits

- 📝 Update changelog
- 📝 Update Metabase supported versions