### PR TITLE
👷 Set up CI for pull requests

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,29 @@
+name: Pull request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: 🧪 Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build provider
+        run: make provider
+
+      - name: Build mbtf
+        run: make mbtf
+
+      - name: Run tests
+        run: make testacc-with-setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
-# Terraform Provider release workflow.
 name: Release
 
-# This GitHub action creates a release when a tag that matches the pattern "v*" (e.g. v0.1.0) is created.
 on:
   push:
     tags:
@@ -14,27 +12,30 @@ permissions:
 
 jobs:
   goreleaser:
+    name: 📦 Release
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           # Allow goreleaser to access older tag information.
           fetch-depth: 0
 
-      - uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
-          cache: true
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           args: release --rm-dist
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,28 @@
 .EXPORT_ALL_VARIABLES:
 .PHONY: set-up-docker tear-down-docker testacc testacc-with-setup clean-testacc provider clean generate
 
-METABASE_USERNAME?=terraform-provider@tests.com
-METABASE_PASSWORD?=$(shell uuidgen)
-METABASE_URL?=http://localhost:3000/api
+ifndef METABASE_USERNAME
+METABASE_USERNAME:=terraform-provider@tests.com
+endif
+ifndef METABASE_PASSWORD
+METABASE_PASSWORD:=$(shell uuidgen)
+endif
+ifndef METABASE_URL
+METABASE_URL:=http://localhost:3000/api
+endif
 
-PG_HOST?=terraform-metabase-pg
-PG_USER?=metabase
-PG_PASSWORD?=$(shell uuidgen)
-PG_DATABASE?=metabase
+ifndef PG_HOST
+PG_HOST:=terraform-metabase-pg
+endif
+ifndef PG_USER
+PG_USER:=metabase
+endif
+ifndef PG_PASSWORD
+PG_PASSWORD:=$(shell uuidgen)
+endif
+ifndef PG_DATABASE
+PG_DATABASE:=metabase
+endif
 
 MBTF_FOLDER:=cmd/mbtf
 


### PR DESCRIPTION
### 📝 Description of the PR

The title says it all. This also fixes variable definitions in the Makefile, which would cause `testacc-with-setup` to fail.

### 🐙 Related GitHub issue(s)

Closes #39.

### 🕰️ Commits

- **👷 Set up CI for pull requests**
- **🔨 Fix Makefile variable definition that should be evaluated immediately**
- **👷 Update actions in release workflow**