### PR TITLE
✨ Support authentication using an API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.tfvars
 *.tfstate*
+.test-api-key
 mbtf
 terraform-provider-metabase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+NEW FEATURES:
+
+- Support authentication using an [API key](https://www.metabase.com/docs/master/people-and-groups/api-keys).
+
 ## 0.4.0 (2024-01-31)
 
 BREAKING CHANGES:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ tear-down-docker:
 	./test-docker.sh tear-down
 
 testacc:
-	TF_ACC=1 go test ./... -v
+	METABASE_API_KEY=$$(cat $(TEST_API_KEY_FILE)) \
+		TF_ACC=1 \
+		go test ./... -v
 
 testacc-with-setup: set-up-docker testacc tear-down-docker
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ MBTF_FILES:=$(shell find $(MBTF_FOLDER) -type f -name '*.go')
 
 PROVIDER_BINARY:=terraform-provider-metabase
 MBTF_BINARY:=mbtf
+TEST_API_KEY_FILE=.test-api-key
 
 set-up-docker:
 	./test-docker.sh
@@ -63,6 +64,9 @@ $(MBTF_BINARY): $(METABASE_CLIENT_FILES) $(MBTF_FILES)
 	cd $(MBTF_FOLDER) && go build -o $(MBTF_BINARY)
 	mv $(MBTF_FOLDER)/$(MBTF_BINARY) .
 
+$(TEST_API_KEY_FILE): set-up-docker
+
 clean: tear-down-docker clean-testacc
 	rm -f $(PROVIDER_BINARY)
 	rm -f $(MBTF_BINARY)
+	rm -f $(TEST_API_KEY_FILE)

--- a/cmd/mbtf/main.go
+++ b/cmd/mbtf/main.go
@@ -24,7 +24,7 @@ func makeMetabaseClient(ctx context.Context, config metabaseConfig) (*metabase.C
 		return nil, errors.New("the Metabase password should be set and non-empty")
 	}
 
-	client, err := metabase.MakeAuthenticatedClient(ctx, config.Endpoint, config.Username, config.Password)
+	client, err := metabase.MakeAuthenticatedClientWithUsernameAndPassword(ctx, config.Endpoint, config.Username, config.Password)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,8 +18,13 @@ While most Terraform resources fully define the Metabase objects using attribute
 ```terraform
 provider "metabase" {
   endpoint = "http://metabase-endpoint.com/api"
+
+  # Authentication can be done using a username and password...
   username = "email@address.com"
   password = "password"
+
+  # ...or using an API key.
+  # api_key = "API key"
 }
 ```
 
@@ -29,5 +34,9 @@ provider "metabase" {
 ### Required
 
 - `endpoint` (String) The URL to the Metabase API.
+
+### Optional
+
+- `api_key` (String, Sensitive) The API key to use to authenticate. This can be used instead of a user name and password.
 - `password` (String, Sensitive) The password to use to authenticate.
 - `username` (String) The user name (or email address) to use to authenticate.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,5 +1,10 @@
 provider "metabase" {
   endpoint = "http://metabase-endpoint.com/api"
+
+  # Authentication can be done using a username and password...
   username = "email@address.com"
   password = "password"
+
+  # ...or using an API key.
+  # api_key = "API key"
 }

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -132,7 +132,7 @@ func TestAccDashboardResource(t *testing.T) {
 		CheckDestroy:             testAccCheckDashboardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + testAccDashboardResource("test", "📈 Dashboard", "📖 Description"),
+				Config: providerApiKeyConfig + testAccDashboardResource("test", "📈 Dashboard", "📖 Description"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDashboardExists("metabase_dashboard.test"),
 					resource.TestCheckResourceAttrSet("metabase_dashboard.test", "id"),
@@ -145,7 +145,7 @@ func TestAccDashboardResource(t *testing.T) {
 				ImportState:  true,
 			},
 			{
-				Config: providerConfig + testAccDashboardResource("test", "📉 Updated", "📕 Updated"),
+				Config: providerApiKeyConfig + testAccDashboardResource("test", "📉 Updated", "📕 Updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("metabase_dashboard.test", "id"),
 					resource.TestCheckResourceAttr("metabase_dashboard.test", "name", "📉 Updated"),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,7 +67,7 @@ func (p *MetabaseProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	authenticatedClient, err := metabase.MakeAuthenticatedClient(ctx, data.Endpoint.ValueString(), data.Username.ValueString(), data.Password.ValueString())
+	authenticatedClient, err := metabase.MakeAuthenticatedClientWithUsernameAndPassword(ctx, data.Endpoint.ValueString(), data.Username.ValueString(), data.Password.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create the Metabase client.", err.Error())
 		return

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -26,7 +26,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 	"metabase": providerserver.NewProtocol6WithError(New("test")()),
 }
 
-var testAccMetabaseClient, _ = metabase.MakeAuthenticatedClient(
+var testAccMetabaseClient, _ = metabase.MakeAuthenticatedClientWithUsernameAndPassword(
 	context.Background(),
 	os.Getenv("METABASE_URL"),
 	os.Getenv("METABASE_USERNAME"),

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -22,6 +22,16 @@ provider "metabase" {
 	os.Getenv("METABASE_PASSWORD"),
 )
 
+var providerApiKeyConfig = fmt.Sprintf(`
+provider "metabase" {
+	endpoint = "%s"
+	api_key = "%s"
+}
+`,
+	os.Getenv("METABASE_URL"),
+	os.Getenv("METABASE_API_KEY"),
+)
+
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){
 	"metabase": providerserver.NewProtocol6WithError(New("test")()),
 }

--- a/metabase-api.yaml
+++ b/metabase-api.yaml
@@ -7,6 +7,7 @@ info:
 
 security:
   - Session: []
+  - ApiKey: []
 
 paths:
   /card:
@@ -639,6 +640,10 @@ components:
       type: apiKey
       in: header
       name: X-Metabase-Session
+    ApiKey:
+      type: apiKey
+      in: header
+      name: X-Api-Key
 
   schemas:
     # Cards.

--- a/metabase/authentication.go
+++ b/metabase/authentication.go
@@ -39,3 +39,18 @@ func MakeAuthenticatedClientWithUsernameAndPassword(ctx context.Context, endpoin
 
 	return authenticatedClient, nil
 }
+
+// Returns an API client configured with the given API key.
+func MakeAuthenticatedClientWithApiKey(ctx context.Context, endpoint string, apiKey string) (*ClientWithResponses, error) {
+	apiKeyProvider, err := securityprovider.NewSecurityProviderApiKey("header", "X-Api-Key", apiKey)
+	if err != nil {
+		return nil, err
+	}
+
+	authenticatedClient, err := NewClientWithResponses(endpoint, WithRequestEditorFn(apiKeyProvider.Intercept))
+	if err != nil {
+		return nil, err
+	}
+
+	return authenticatedClient, nil
+}

--- a/metabase/authentication.go
+++ b/metabase/authentication.go
@@ -9,7 +9,7 @@ import (
 
 // Authenticates to the Metabase API using the given username and password, and returns an API client configured with
 // the session obtained during authentication.
-func MakeAuthenticatedClient(ctx context.Context, endpoint string, username string, password string) (*ClientWithResponses, error) {
+func MakeAuthenticatedClientWithUsernameAndPassword(ctx context.Context, endpoint string, username string, password string) (*ClientWithResponses, error) {
 	client, err := NewClientWithResponses(endpoint)
 	if err != nil {
 		return nil, err

--- a/metabase/client.gen.go
+++ b/metabase/client.gen.go
@@ -17,6 +17,7 @@ import (
 )
 
 const (
+	ApiKeyScopes  = "ApiKey.Scopes"
 	SessionScopes = "Session.Scopes"
 )
 


### PR DESCRIPTION
### 📝 Description of the PR

This PR implements support for authentication using an [API key](https://www.metabase.com/docs/master/people-and-groups/api-keys) rather than a username and a password.

### 🐙 Related GitHub issue(s)

Closes #44.

### 🕰️ Commits

- **🔨 Generate an API key when setting up the test environment**
- **🙈 Ignore test API key file**
- **👽 Define the API key security scheme for the Metabase API**
- **♻️ Rename existing authentication function**
- **✨ Implement API key authentication for the Metabase client**
- **✨ Support API key authentication for the provider**
- **📝 Document API key authentication**
- **📝 Update changelog**