### PR TITLE
🔨 Fix bug for Metabase Pro instances with modified analytics permissions

### DIFF
--- a/metabase-api.yaml
+++ b/metabase-api.yaml
@@ -1279,12 +1279,20 @@ components:
             - write
             - none
         schemas:
-          type: string
-          description: Whether "Data access" is allowed.
-          enum:
-            - full
-            - all
-            - none
+          # The `schemas` property can either be a string or an object. The API returns an object in two cases:
+          #   1. Permissions are set to "granular" and some tables have different permissions than others
+          #   2. Permissions are modified on the Metabase Analytics database (available in pro version)
+          #
+          # Proper support for these cases requires more research. For now, we only specify the string type. It's under
+          # `oneOf` so the generated client doesn't error when it receives a non-string response. Application code is
+          # expected to detect and handle these cases.
+          oneOf:
+            - type: string
+              description: Whether "Data access" is allowed.
+              enum:
+                - full
+                - all
+                - none
     # Sessions.
     Session:
       type: object

--- a/metabase/client.gen.go
+++ b/metabase/client.gen.go
@@ -59,11 +59,11 @@ const (
 	PermissionsGraphDatabaseAccessNativeWrite PermissionsGraphDatabaseAccessNative = "write"
 )
 
-// Defines values for PermissionsGraphDatabaseAccessSchemas.
+// Defines values for PermissionsGraphDatabaseAccessSchemas0.
 const (
-	PermissionsGraphDatabaseAccessSchemasAll  PermissionsGraphDatabaseAccessSchemas = "all"
-	PermissionsGraphDatabaseAccessSchemasFull PermissionsGraphDatabaseAccessSchemas = "full"
-	PermissionsGraphDatabaseAccessSchemasNone PermissionsGraphDatabaseAccessSchemas = "none"
+	PermissionsGraphDatabaseAccessSchemas0All  PermissionsGraphDatabaseAccessSchemas0 = "all"
+	PermissionsGraphDatabaseAccessSchemas0Full PermissionsGraphDatabaseAccessSchemas0 = "full"
+	PermissionsGraphDatabaseAccessSchemas0None PermissionsGraphDatabaseAccessSchemas0 = "none"
 )
 
 // Defines values for PermissionsGraphDatabasePermissionsDetails.
@@ -429,17 +429,20 @@ type PermissionsGraph struct {
 // PermissionsGraphDatabaseAccess The permissions for a single access type.
 type PermissionsGraphDatabaseAccess struct {
 	// Native Whether "Native query editing" is allowed.
-	Native *PermissionsGraphDatabaseAccessNative `json:"native,omitempty"`
-
-	// Schemas Whether "Data access" is allowed.
-	Schemas *PermissionsGraphDatabaseAccessSchemas `json:"schemas,omitempty"`
+	Native  *PermissionsGraphDatabaseAccessNative   `json:"native,omitempty"`
+	Schemas *PermissionsGraphDatabaseAccess_Schemas `json:"schemas,omitempty"`
 }
 
 // PermissionsGraphDatabaseAccessNative Whether "Native query editing" is allowed.
 type PermissionsGraphDatabaseAccessNative string
 
-// PermissionsGraphDatabaseAccessSchemas Whether "Data access" is allowed.
-type PermissionsGraphDatabaseAccessSchemas string
+// PermissionsGraphDatabaseAccessSchemas0 Whether "Data access" is allowed.
+type PermissionsGraphDatabaseAccessSchemas0 string
+
+// PermissionsGraphDatabaseAccess_Schemas defines model for PermissionsGraphDatabaseAccess.Schemas.
+type PermissionsGraphDatabaseAccess_Schemas struct {
+	union json.RawMessage
+}
 
 // PermissionsGraphDatabasePermissions The permissions related to a single database.
 type PermissionsGraphDatabasePermissions struct {
@@ -1047,6 +1050,42 @@ func (t DatabaseDetails) MarshalJSON() ([]byte, error) {
 }
 
 func (t *DatabaseDetails) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
+
+// AsPermissionsGraphDatabaseAccessSchemas0 returns the union data inside the PermissionsGraphDatabaseAccess_Schemas as a PermissionsGraphDatabaseAccessSchemas0
+func (t PermissionsGraphDatabaseAccess_Schemas) AsPermissionsGraphDatabaseAccessSchemas0() (PermissionsGraphDatabaseAccessSchemas0, error) {
+	var body PermissionsGraphDatabaseAccessSchemas0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromPermissionsGraphDatabaseAccessSchemas0 overwrites any union data inside the PermissionsGraphDatabaseAccess_Schemas as the provided PermissionsGraphDatabaseAccessSchemas0
+func (t *PermissionsGraphDatabaseAccess_Schemas) FromPermissionsGraphDatabaseAccessSchemas0(v PermissionsGraphDatabaseAccessSchemas0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergePermissionsGraphDatabaseAccessSchemas0 performs a merge with any union data inside the PermissionsGraphDatabaseAccess_Schemas, using the provided PermissionsGraphDatabaseAccessSchemas0
+func (t *PermissionsGraphDatabaseAccess_Schemas) MergePermissionsGraphDatabaseAccessSchemas0(v PermissionsGraphDatabaseAccessSchemas0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JsonMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t PermissionsGraphDatabaseAccess_Schemas) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *PermissionsGraphDatabaseAccess_Schemas) UnmarshalJSON(b []byte) error {
 	err := t.union.UnmarshalJSON(b)
 	return err
 }

--- a/metabase/utils.go
+++ b/metabase/utils.go
@@ -3,6 +3,9 @@ package metabase
 // The default ID of the `Administrators` permissions group, created automatically by Terraform.
 const AdministratorsPermissionsGroupId = 2
 
+// The ID of the `Metabase Analytics` database, automatically created for pro plans.
+const MetabaseAnalyticsDatabaseId = "13371337"
+
 // The list of JSON attributes in a `Card` object that are needed to fully define the card, e.g. when creating it.
 var DefiningCardAttributes = map[string]bool{
 	"cache_ttl":              true,


### PR DESCRIPTION
### 📝 Description of the PR

Addresses errors in the `metabase_permissions_graph` resource caused by changing permissions in Metabase Analytics (pro feature). When permissions are changed, the response changes the `schemas` property from a string (expected) to an object (unexpected). 

This PR is a workaround. The idea is to simply ignore permissions related to the metabase analytics database. Adding proper support for the analytics database would be a bigger undertaking. Until that happens, this change will allow Metabase Pro instances with modified analytics permissions to use the provider.

Updates the OpenAPI spec to wrap the `schemas` property in a `oneOf`. This ensures the client doesn't error when it receives an object rather than a string. Then, permissions related to the Metabase Analytics database (ID `13371337`) are simply ignored. 

NOTE: a similar thing can happen if a user sets "granular" database permissions in the UI. Like the case with modified analytics permissions, the response changes to an object instead of a string. I added an actionable error message in this case.

### 🐙 Related GitHub issue(s)

https://github.com/flovouin/terraform-provider-metabase/issues/48

### 🕰️ Commits

<!-- Insert the list of commits here. (They are automatically generated when using `gh pr create`.) -->
