### PR TITLE
✨ Dashboard filtering parameters (linking filters)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+NEW FEATURES:
+
+- Support [linking filters](https://www.metabase.com/learn/dashboards/linking-filters) (aka filtering parameters in the API).
+
 ## 0.5.1 (2024-04-07)
 
 BUG FIXES:

--- a/internal/provider/dashboard_resource_test.go
+++ b/internal/provider/dashboard_resource_test.go
@@ -18,13 +18,24 @@ resource "metabase_dashboard" "%s" {
 
   parameters_json = jsonencode([
     {
-      id        = "83e68ca2"
-      name      = "Date range"
-      slug      = "date_filter"
-      type      = "date/all-options"
-      sectionId = "date"
-      default   = "past30days"
+      "name": "Month and Year",
+      "slug": "month_and_year",
+      "id": "fb55bed",
+      "type": "date/month-year",
+      "sectionId": "date",
+      "required": true,
+      "default": "2024-02"
     },
+    {
+      "name": "Text",
+      "slug": "text",
+      "id": "dac08e9",
+      "type": "string/=",
+      "sectionId": "string",
+      "filteringParameters": [
+        "fb55bed"
+      ]
+    }
   ])
 
   cards_json = jsonencode([

--- a/metabase-api.yaml
+++ b/metabase-api.yaml
@@ -1003,6 +1003,14 @@ components:
             - type: string
             - type: array
           description: The default value for the parameter.
+        required:
+          type: boolean
+          description: Whether the parameter is required.
+        filteringParameters:
+          type: array
+          description: A list of IDs of parameters used to limit the values of this parameter.
+          items:
+            type: string
       required:
         - id
         - name

--- a/metabase/client.gen.go
+++ b/metabase/client.gen.go
@@ -316,11 +316,17 @@ type DashboardParameter struct {
 	// Default The default value for the parameter.
 	Default *DashboardParameter_Default `json:"default,omitempty"`
 
+	// FilteringParameters A list of IDs of parameters used to limit the values of this parameter.
+	FilteringParameters *[]string `json:"filteringParameters,omitempty"`
+
 	// Id The ID of the parameter.
 	Id string `json:"id"`
 
 	// Name The displayed name for the parameter.
 	Name string `json:"name"`
+
+	// Required Whether the parameter is required.
+	Required *bool `json:"required,omitempty"`
 
 	// SectionId The ID of the section.
 	SectionId string `json:"sectionId"`


### PR DESCRIPTION
### 📝 Description of the PR

This PR implements support for linking filters. This simply required to declare the corresponding fields in the OpenAPI.

### 🐙 Related GitHub issue(s)

Closes #53.

### 🕰️ Commits

- **👽 Add the required and filteringParameters properties to DashboardParameter**
- **✅ Update the dashboard resource test with a filtering parameter**
- **📝 Update changelog**