### PR TITLE
🔖 Prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.8.0 (2024-09-08)
+
 BREAKING CHANGES:
 
 - Support Metabase v\*.50, and drop support for earlier versions.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Unfortunately, this provider relies on the Metabase API which is [subject to bre
 | Provider version \ Metabase version | .44 | .45 | .46 | .47 | .48 | .49 | .50 |
 | ----------------------------------: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 |                              <= 0.3 | ✅  | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  |
-|                              >= 0.4 | ❌  | ❌  | ❌  | ❌  | ✅  | ✅  | ❌  |
+|                       >= 0.4, < 0.8 | ❌  | ❌  | ❌  | ❌  | ✅  | ✅  | ❌  |
+|                              >= 0.8 | ❌  | ❌  | ❌  | ❌  | ❌  | ❌  | ✅  |
 
 ## 🔨 `mbtf` importer tool
 


### PR DESCRIPTION
### 📝 Description of the PR

BREAKING CHANGES:

- Support Metabase v\*.50, and drop support for earlier versions.
- `metabase_permissions_graph`'s permissions support two new fields: `view_data` and `create_queries`. The `native` field is no longer supported.

### 🐙 Related GitHub issue(s)

N/A

### 🕰️ Commits

- **📝 Update changelog**
- **📝 Update supported versions**