### PR TITLE
🥅 Catch and return an error when the API returns a response that could not be parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+BUG FIXES:
+
+- Catch and return an error when the API returns a response that could not be parsed.
+
 ## 0.8.0 (2024-09-08)
 
 BREAKING CHANGES:

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -72,6 +72,15 @@ func checkMetabaseResponse(r metabase.MetabaseResponse, err error, statusCodes [
 		}
 	}
 
+	if r.HasExpectedStatusWithoutExpectedBody() {
+		return diag.Diagnostics{
+			diag.NewErrorDiagnostic(
+				fmt.Sprintf("Unexpected response while calling the Metabase API for operation '%s'.", operation),
+				fmt.Sprintf("Status code: %d, failed to parse body: %s", r.StatusCode(), r.BodyString()),
+			),
+		}
+	}
+
 	for _, s := range statusCodes {
 		if r.StatusCode() == s {
 			return diag.Diagnostics{}

--- a/metabase/metabase_response.go
+++ b/metabase/metabase_response.go
@@ -5,120 +5,237 @@ package metabase
 type MetabaseResponse interface {
 	StatusCode() int
 	BodyString() string
+	HasExpectedStatusWithoutExpectedBody() bool
 }
 
 func (r *CreateCardResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *CreateCardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *GetCardResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *GetCardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *UpdateCardResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *UpdateCardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *GetCollectionPermissionsGraphResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *GetCollectionPermissionsGraphResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *ReplaceCollectionPermissionsGraphResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *ReplaceCollectionPermissionsGraphResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *CreateCollectionResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *CreateCollectionResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *GetCollectionResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *GetCollectionResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *UpdateCollectionResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *UpdateCollectionResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *ListCollectionItemsResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *ListCollectionItemsResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *CreateDashboardResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *CreateDashboardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *GetDashboardResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *GetDashboardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *UpdateDashboardResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *UpdateDashboardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *DeleteDashboardResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *DeleteDashboardResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return false
+}
+
 func (r *CreateDatabaseResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *CreateDatabaseResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *GetDatabaseResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *GetDatabaseResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *UpdateDatabaseResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *UpdateDatabaseResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *DeleteDatabaseResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *DeleteDatabaseResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return false
+}
+
 func (r *GetPermissionsGraphResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *GetPermissionsGraphResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *ReplacePermissionsGraphResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *ReplacePermissionsGraphResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *CreatePermissionsGroupResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *CreatePermissionsGroupResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *GetPermissionsGroupResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *GetPermissionsGroupResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *UpdatePermissionsGroupResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *UpdatePermissionsGroupResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *DeletePermissionsGroupResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *DeletePermissionsGroupResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return false
+}
+
 func (r *CreateSessionResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *CreateSessionResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *ListTablesResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *ListTablesResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *GetTableMetadataResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *GetTableMetadataResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }
 
 func (r *UpdateTableResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *UpdateTableResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *GetFieldResponse) BodyString() string {
 	return string(r.Body)
 }
 
+func (r *GetFieldResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
+}
+
 func (r *UpdateFieldResponse) BodyString() string {
 	return string(r.Body)
+}
+
+func (r *UpdateFieldResponse) HasExpectedStatusWithoutExpectedBody() bool {
+	return r.StatusCode() == 200 && r.JSON200 == nil
 }


### PR DESCRIPTION
### 📝 Description of the PR

This fixes a bug where the provider would panic instead of returning an error when the Metabase API returns an unexpected response body that cannot be parsed (although it returns the expected status code).

### 🐙 Related GitHub issue(s)

Fixes #69 (although the actual error is the provider being misconfigured).

### 🕰️ Commits

- **✨ Add HasExpectedStatusWithoutExpectedBody to the MetabaseResponse interface**
- **🥅 Catch and return an error when the API returns a response that could not be parsed**
- **📝 Update changelog**