### PR TITLE
🔖 Prepare 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.8.1 (2024-09-22)
+
 BUG FIXES:
 
 - Catch and return an error when the API returns a response that could not be parsed.


### PR DESCRIPTION
### 📝 Description of the PR

BUG FIXES:

- Catch and return an error when the API returns a response that could not be parsed.

### 🐙 Related GitHub issue(s)

N/A

### 🕰️ Commits

- **📝 Update changelog**