### PR TITLE
🐛 Ignore `aggregation-idents` and `breakout-idents` in card queries if they are not part of the definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ NEW FEATURES:
 
 - Handle `metabase_permissions_graph` `view_data` as either a simple string or a serialized JSON object.
 
+BUG FIXES:
+
+- Ignore `aggregation-idents` and `breakout-idents` in the response when they are not part of the card model.
+
 ## 0.8.1 (2024-09-22)
 
 BUG FIXES:

--- a/cmd/mbtf/main.go
+++ b/cmd/mbtf/main.go
@@ -36,7 +36,6 @@ func makeMetabaseClient(ctx context.Context, config metabaseConfig) (*metabase.C
 func setUpDatabases(ctx context.Context, config databasesConfig, ic importer.ImportContext) error {
 	definitions := make([]importer.ExistingDatabaseDefinition, 0, len(config.Mapping))
 	for _, d := range config.Mapping {
-		d := d
 		var id *int
 		var name *string
 
@@ -66,7 +65,6 @@ func setUpDatabases(ctx context.Context, config databasesConfig, ic importer.Imp
 func setUpCollections(ctx context.Context, config collectionsConfig, ic importer.ImportContext) error {
 	definitions := make([]importer.ExistingCollectionDefinition, 0, len(config.Mapping))
 	for _, d := range config.Mapping {
-		d := d
 		var id *string
 		var name *string
 

--- a/internal/importer/dashboard.go
+++ b/internal/importer/dashboard.go
@@ -38,7 +38,7 @@ type dashboardTemplateData struct {
 }
 
 // Replaces the reference to a card in a single "dashcard" by an `importedCard`.
-func (ic *ImportContext) insertCardReference(ctx context.Context, obj map[string]interface{}) error {
+func (ic *ImportContext) insertCardReference(ctx context.Context, obj map[string]any) error {
 	cardIdAny, ok := obj[metabase.CardIdAttribute]
 	if !ok {
 		return errors.New("unable to find card_id in object")
@@ -66,7 +66,7 @@ func (ic *ImportContext) insertCardReference(ctx context.Context, obj map[string
 }
 
 // Replaces all references to cards and fields in a "dashcard" by their `imported*` counterpart.
-func (ic *ImportContext) insertReferencesInCard(ctx context.Context, card map[string]interface{}) error {
+func (ic *ImportContext) insertReferencesInCard(ctx context.Context, card map[string]any) error {
 	// The dashcard has a `card_id` at its root that should be replaced.
 	err := ic.insertCardReference(ctx, card)
 	if err != nil {
@@ -79,13 +79,13 @@ func (ic *ImportContext) insertReferencesInCard(ctx context.Context, card map[st
 		return nil
 	}
 
-	mappings, ok := mappingsAny.([]interface{})
+	mappings, ok := mappingsAny.([]any)
 	if !ok {
 		return errors.New("unable to convert parameter_mappings to array in dashboard card")
 	}
 
 	for _, m := range mappings {
-		mapping, ok := m.(map[string]interface{})
+		mapping, ok := m.(map[string]any)
 		if !ok {
 			return errors.New("unable to convert parameter mapping to object in dashboard card")
 		}
@@ -102,7 +102,7 @@ func (ic *ImportContext) insertReferencesInCard(ctx context.Context, card map[st
 			continue
 		}
 
-		target, ok := targetAny.([]interface{})
+		target, ok := targetAny.([]any)
 		if !ok {
 			// For all we know, `target` might have a different structure.
 			continue
@@ -126,14 +126,14 @@ func (ic *ImportContext) makeDashboardCardsHcl(ctx context.Context, cards []meta
 	}
 
 	// Using the base unmarshalling without typing actually makes it easier to replace card IDs with `importedCard`s.
-	var cardsUntyped []interface{}
+	var cardsUntyped []any
 	err = json.Unmarshal(cardsJson, &cardsUntyped)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, c := range cardsUntyped {
-		card, ok := c.(map[string]interface{})
+		card, ok := c.(map[string]any)
 		if !ok {
 			return nil, errors.New("unable to parse dashboard card")
 		}

--- a/internal/importer/field.go
+++ b/internal/importer/field.go
@@ -10,9 +10,9 @@ import (
 // Searches a JSON object or array recursively to find references to `Field` Metabase objects. The references are
 // replaced by an `importedField`, which is marshalled as a reference to the corresponding Terraform table data source
 // instead.
-func (ic *ImportContext) insertFieldReferencesRecursively(ctx context.Context, obj interface{}) error {
+func (ic *ImportContext) insertFieldReferencesRecursively(ctx context.Context, obj any) error {
 	switch typedObj := obj.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for _, v := range typedObj {
 			err := ic.insertFieldReferencesRecursively(ctx, v)
 			if err != nil {
@@ -21,7 +21,7 @@ func (ic *ImportContext) insertFieldReferencesRecursively(ctx context.Context, o
 		}
 
 		return nil
-	case []interface{}:
+	case []any:
 		// A reference to a field is an array with the form `["field", <fieldId>, ...]`.
 		// This first tries to find such a reference in the array. If it does not, the array is then searched recursively.
 		inserted, err := ic.tryInsertFieldReference(ctx, typedObj)
@@ -46,7 +46,7 @@ func (ic *ImportContext) insertFieldReferencesRecursively(ctx context.Context, o
 // Tries to replace the reference to a field ID by the corresponding `importedField`.
 // If the given array is not a reference to a field, this function returns `false`. If the array is a reference to a
 // field, but the field cannot be imported, the function will return an error.
-func (ic *ImportContext) tryInsertFieldReference(ctx context.Context, array []interface{}) (bool, error) {
+func (ic *ImportContext) tryInsertFieldReference(ctx context.Context, array []any) (bool, error) {
 	if len(array) < 2 {
 		return false, nil
 	}

--- a/internal/importer/marshalling.go
+++ b/internal/importer/marshalling.go
@@ -36,29 +36,29 @@ var collectionRegexp = regexp.MustCompile("\\\"!!(tonumber\\(metabase_collection
 
 // Marshals an `importedCard` as a placeholder which references the corresponding Terraform resource.
 func (c *importedCard) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"!!metabase_card.%s.id!!\"", c.Slug)), nil
+	return fmt.Appendf(nil, "\"!!metabase_card.%s.id!!\"", c.Slug), nil
 }
 
 // Marshals an `importedField` as a placeholder which references the corresponding Terraform table data source, and
 // accesses the `field` attribute for this `metabase_table`.
 func (f *importedField) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"!!metabase_table.%s.fields[%s]!!\"", f.ParentTable.Slug, f.Field.Name)), nil
+	return fmt.Appendf(nil, "\"!!metabase_table.%s.fields[%s]!!\"", f.ParentTable.Slug, f.Field.Name), nil
 }
 
 // Marshals an `importedTable` as a placeholder which references the corresponding Terraform data source.
 func (t *importedTable) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"!!metabase_table.%s.id!!\"", t.Slug)), nil
+	return fmt.Appendf(nil, "\"!!metabase_table.%s.id!!\"", t.Slug), nil
 }
 
 // Marshals an `importedDatabase` as a placeholder which references the corresponding Terraform resource.
 func (d *importedDatabase) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"!!metabase_database.%s.id!!\"", d.Slug)), nil
+	return fmt.Appendf(nil, "\"!!metabase_database.%s.id!!\"", d.Slug), nil
 }
 
 // Marshals an `importedCollection` as a placeholder which references the corresponding Terraform resource.
 // Only collections with an integer ID are supported.
 func (c *importedCollection) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"!!tonumber(metabase_collection.%s.id)!!\"", c.Slug)), nil
+	return fmt.Appendf(nil, "\"!!tonumber(metabase_collection.%s.id)!!\"", c.Slug), nil
 }
 
 // Replaces all placeholders introduced by marshalling `imported*` structures to JSON.

--- a/internal/provider/card_resource.go
+++ b/internal/provider/card_resource.go
@@ -76,7 +76,7 @@ Because the content of a card is complex and can vary a lot between cards, the f
 }
 
 // Parses the (integer) ID of the card from a raw Card JSON object returned by the Metabase API.
-func getIdFromRawCard(card map[string]interface{}, strResp string) (types.Int64, diag.Diagnostics) {
+func getIdFromRawCard(card map[string]any, strResp string) (types.Int64, diag.Diagnostics) {
 	idAny, ok := card["id"]
 	if !ok {
 		return types.Int64Unknown(), diag.Diagnostics{
@@ -123,7 +123,7 @@ func updateModelFromCardBytes(cardBytes []byte, data *CardResourceModel) diag.Di
 	var diags diag.Diagnostics
 
 	// Unmarshalling to a map such that we can perform low-level JSON manipulation on the card.
-	var card map[string]interface{}
+	var card map[string]any
 	err := json.Unmarshal(cardBytes, &card)
 	if err != nil {
 		diags.AddError("Could not deserialize card response from the Metabase API.", err.Error())
@@ -146,7 +146,7 @@ func updateModelFromCardBytes(cardBytes []byte, data *CardResourceModel) diag.Di
 	}
 
 	// Unmarshals the card from the plan or state, i.e. the known and expected configuration for the card.
-	var existingCard map[string]interface{}
+	var existingCard map[string]any
 	if !data.Json.IsNull() {
 		err := json.Unmarshal([]byte(data.Json.ValueString()), &existingCard)
 		if err != nil {

--- a/internal/provider/card_resource_test.go
+++ b/internal/provider/card_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func testAccCardResource(name string, displayName string) string {
+func testAccCardResource(name string, displayName string, queryOptions string) string {
 	// This references the sample database, which should always have ID 1.
 	return fmt.Sprintf(`
 resource "metabase_card" "%s" {
@@ -22,6 +22,7 @@ resource "metabase_card" "%s" {
     cache_ttl           = null
     query_type          = "query"
     dataset_query = {
+      %s
       database = 1
       type     = "query"
       query = {
@@ -37,6 +38,7 @@ resource "metabase_card" "%s" {
 `,
 		name,
 		displayName,
+		queryOptions,
 	)
 }
 
@@ -93,7 +95,7 @@ func TestAccCardResource(t *testing.T) {
 		CheckDestroy:             testAccCheckCardDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + testAccCardResource("test", "🪪"),
+				Config: providerConfig + testAccCardResource("test", "🪪", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckCardExists("metabase_card.test"),
 					resource.TestCheckResourceAttrSet("metabase_card.test", "id"),
@@ -105,7 +107,14 @@ func TestAccCardResource(t *testing.T) {
 				ImportState:  true,
 			},
 			{
-				Config: providerConfig + testAccCardResource("test", "💳"),
+				Config: providerConfig + testAccCardResource("test", "💳", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("metabase_card.test", "id"),
+					resource.TestCheckResourceAttrSet("metabase_card.test", "json"),
+				),
+			},
+			{
+				Config: providerConfig + testAccCardResource("test", "💳", "breakout-idents = { 0 = \"ABCD\" }"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("metabase_card.test", "id"),
 					resource.TestCheckResourceAttrSet("metabase_card.test", "json"),

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -190,7 +190,7 @@ func makeCustomDetailsFromResponseBody(ctx context.Context, db metabase.Database
 	}
 
 	var detailsJson string
-	var existingDetails map[string]interface{}
+	var existingDetails map[string]any
 	redactedAttributesValue := types.SetNull(types.StringType)
 	if !data.CustomDetails.IsNull() {
 		var cd CustomDetails
@@ -336,7 +336,7 @@ func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceMod
 
 		engine = metabase.DatabaseEngine(cd.Engine.ValueString())
 
-		var rawDetails map[string]interface{}
+		var rawDetails map[string]any
 		err := json.Unmarshal([]byte(cd.DetailsJson.ValueString()), &rawDetails)
 		if err != nil {
 			diags.AddError("Unable to deserialize details_json as an object.", err.Error())

--- a/internal/provider/permissions_graph_resource.go
+++ b/internal/provider/permissions_graph_resource.go
@@ -202,7 +202,7 @@ func makePermissionsObjectFromDatabasePermissions(ctx context.Context, groupId i
 		existingViewData = existing.ViewData.ValueStringPointer()
 
 		if existingViewData != nil {
-			var viewDataObject map[string]interface{}
+			var viewDataObject map[string]any
 			err := json.Unmarshal([]byte(*existingViewData), &viewDataObject)
 			existingViewDataIsJson = err == nil
 		}
@@ -411,7 +411,7 @@ func makePermissionsGraphFromModel(ctx context.Context, data PermissionsGraphRes
 
 		viewDataString := p.ViewData.ValueString()
 		var viewData metabase.PermissionsGraphDatabasePermissions_ViewData
-		var viewDataObject map[string]interface{}
+		var viewDataObject map[string]any
 		// Tries to parse the string as JSON.
 		if err := json.Unmarshal([]byte(viewDataString), &viewDataObject); err == nil {
 			viewData.FromPermissionsGraphDatabasePermissionsViewData1(

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 
 	"github.com/flovouin/terraform-provider-metabase/metabase"
@@ -81,10 +82,8 @@ func checkMetabaseResponse(r metabase.MetabaseResponse, err error, statusCodes [
 		}
 	}
 
-	for _, s := range statusCodes {
-		if r.StatusCode() == s {
-			return diag.Diagnostics{}
-		}
+	if slices.Contains(statusCodes, r.StatusCode()) {
+		return diag.Diagnostics{}
 	}
 
 	return diag.Diagnostics{


### PR DESCRIPTION
### 📝 Description of the PR

This hopefully fixes #76, by ignoring fields in a card query that are automatically added by Metabase.
If those fields are provided in the card definition, they are kept (as Metabase seems to keep them intact and return them).

### 🐙 Related GitHub issue(s)

Closes #76.

### 🕰️ Commits

- **🐛 Ignore aggregation-idents and breakout-idents in the response when they are not part of the card model**
- **♻️ Apply modernizer to code**