### PR TITLE
feat(mbtf): add support for API key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,13 @@ Running the tool will connect to the Metabase API, list all dashboards matching 
 metabase:
   # The URL to the Metabase API. Usually suffixed with `/api`.
   endpoint: http://metabase-endpoint.com/api
-  # The following parameters can (and probably should) be defined as environment variables `MBTF_METABASE_USERNAME` and
-  # `MBTF_METABASE_PASSWORD`.
+  # The following authentication parameters can be defined as environment variables:
+  # - To use username/password authentication, set `MBTF_METABASE_USERNAME` and `MBTF_METABASE_PASSWORD`.
+  # - To use API key authentication, set `MBTF_METABASE_APIKEY`.
+  # Only one authentication method is required.
   username: email@address.com
   password: password
+  # apikey: your_metabase_api_key
 
 # Databases are not imported by `mbtf` and should already be defined in the Terraform configuration.
 # This defines how the mapping is made between databases found in the Metabase API and Terraform.

--- a/cmd/mbtf/config.go
+++ b/cmd/mbtf/config.go
@@ -23,6 +23,7 @@ type metabaseConfig struct {
 	Endpoint string `koanf:"endpoint"` // The URL to the Metabase API.
 	Username string `koanf:"username"` // The username (email address) to use to log in.
 	Password string `koanf:"password"` // The password to use to log in.
+	APIKey   string `koanf:"apikey"`   // The API key to use to log in.
 }
 
 // A single mapping from a database to a Terraform resource name.

--- a/cmd/mbtf/main.go
+++ b/cmd/mbtf/main.go
@@ -12,6 +12,15 @@ import (
 
 // Initializes the Metabase API client using the configuration.
 func makeMetabaseClient(ctx context.Context, config metabaseConfig) (*metabase.ClientWithResponses, error) {
+	if len(config.APIKey) > 0 {
+		client, err := metabase.MakeAuthenticatedClientWithApiKey(ctx, config.Endpoint, config.APIKey)
+		if err != nil {
+			return nil, err
+		}
+
+		return client, nil
+	}
+
 	if len(config.Endpoint) == 0 {
 		return nil, errors.New("the Metabase endpoint should be set and non-empty")
 	}


### PR DESCRIPTION
### 📝 Description of the PR

This PR introduces support for API key-based authentication to `mbtf`, offering more flexibility to the existing username/password method. In our case, username/password authentication is not available on our Metabase instance.

### 🐙 Related GitHub issue(s)

No issues on GitHub have been created.

### 🕰️ Commits

* [feat(auth): add support for API key authentication for Metabase](https://github.com/flovouin/terraform-provider-metabase/commit/f12cd56e703e9be804165bed8d2bd16b78ab6945)