### PR TITLE
feat: Add support for dashboard tabs in Terraform provider

### DIFF
--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -63,9 +63,15 @@ resource "metabase_dashboard" "some_great_dashboard" {
     },
   ])
 
+  tabs_json = jsonencode([
+    { name = "My first tab!", id = 1 },
+    { name = "Second tab", id = 2 }
+  ])
+
   cards_json = jsonencode([
     {
       card_id                = metabase_card.some_great_insights.id
+      dashboard_tab_id       = 1
       col                    = 7
       row                    = 0
       size_x                 = 11
@@ -85,6 +91,7 @@ resource "metabase_dashboard" "some_great_dashboard" {
     },
     {
       card_id = null
+      dashboard_tab_id = 2
       col     = 0
       row     = 0
       size_x  = 7
@@ -122,6 +129,7 @@ resource "metabase_dashboard" "some_great_dashboard" {
 - `collection_position` (Number) The position of the dashboard in the collection.
 - `description` (String) A description for the dashboard.
 - `parameters_json` (String) A list of parameters for the dashboard, that the user can tweak, as a JSON string.
+- `tabs_json` (String) The list of tabs in the dashboard, as a JSON string. Each tab should have an `id` (positive integer, unique within the dashboard) and a `name`. Cards can reference tabs using `dashboard_tab_id` with the same ID.
 
 ### Read-Only
 

--- a/metabase-api.yaml
+++ b/metabase-api.yaml
@@ -998,6 +998,11 @@ components:
           description: The list of cards in the dashboard.
           items:
             $ref: "#/components/schemas/DashboardCard"
+        tabs:
+          type: array
+          description: The list of tabs in the dashboard.
+          items:
+            $ref: "#/components/schemas/DashboardTab"
       required:
         - id
         - name
@@ -1008,6 +1013,7 @@ components:
         - archived
         - parameters
         - dashcards
+        - tabs
     CreateDashboardBody:
       type: object
       description: The body of the payload when creating a dashboard.
@@ -1077,6 +1083,11 @@ components:
           description: The list of cards in the dashboard.
           items:
             $ref: "#/components/schemas/DashboardCard"
+        tabs:
+          type: array
+          description: The list of tabs in the dashboard.
+          items:
+            $ref: "#/components/schemas/DashboardTab"
     DashboardParameter:
       type: object
       description: A parameter for a dashboard, that the user can tweak.
@@ -1159,6 +1170,19 @@ components:
         - size_x
         - size_y
         - visualization_settings
+    DashboardTab:
+      type: object
+      description: A tab within a dashboard.
+      properties:
+        id:
+          type: integer
+          description: The ID of the dashboard tab.
+        name:
+          type: string
+          description: The name of the tab.
+      required:
+        - id
+        - name
     # Databases.
     Database:
       type: object

--- a/metabase/client.gen.go
+++ b/metabase/client.gen.go
@@ -289,6 +289,9 @@ type Dashboard struct {
 
 	// Parameters A list of parameters for the dashboard, that the user can tweak.
 	Parameters []DashboardParameter `json:"parameters"`
+
+	// Tabs The list of tabs in the dashboard.
+	Tabs []DashboardTab `json:"tabs"`
 }
 
 // DashboardCard A card within a dashboard.
@@ -358,6 +361,15 @@ type DashboardParameterDefault1 = []interface{}
 // DashboardParameter_Default The default value for the parameter.
 type DashboardParameter_Default struct {
 	union json.RawMessage
+}
+
+// DashboardTab A tab within a dashboard.
+type DashboardTab struct {
+	// Id The ID of the dashboard tab.
+	Id int `json:"id"`
+
+	// Name The name of the tab.
+	Name string `json:"name"`
 }
 
 // Database An external database that can be queried by cards and dashboards.
@@ -607,6 +619,9 @@ type UpdateDashboardBody struct {
 
 	// Parameters A list of parameters for the dashboard, that the user can tweak.
 	Parameters *[]DashboardParameter `json:"parameters,omitempty"`
+
+	// Tabs The list of tabs in the dashboard.
+	Tabs *[]DashboardTab `json:"tabs,omitempty"`
 }
 
 // UpdateDatabaseBody The payload used to update an existing database.


### PR DESCRIPTION
### 📝 Description of the PR

This PR adds support for dashboard tabs in the Terraform provider.

It **does not** add support for tabs in the importer - I did not dig in that part of the codebase, so I did not feel confident updating it.

👉 Same disclaimer as #93 - part of this PR was made using Claude Opus 4.5

### ⚙️ Some logic

Like `dashcards`, I'm using negative values to make Metabase create new tabs. This leads to Metabase generating a new ID for every tab. I get these IDs in order and map them back to the user-provided ID, which I then use to map the cards' `dashboard_tab_id`. 

It does feel a bit brittle, and I'm not sure how it would react to some operations (ex: swapping two tabs without any other change), but the basic operations (adding tabs, removing tabs, updating IDs) do work...

I tested it locally on my use-case and it works fine.

<!-- What does this PR do? -->

### 🐙 Related GitHub issue(s)

It implements part of #56, though it does not solve it entirely since `mbtf` won't import existing tabs.

<!-- List the GitHub issues that should be closed thanks to this PR, e.g. "Closes #001.". -->

### 🕰️ Commits

<!-- Insert the list of commits here. (They are automatically generated when using `gh pr create`.) -->
