### PR TITLE
🔖 Prepare v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.14.2 (2026-05-29)
+
 BUG FIXES:
 
 - Handle `metabase_permissions_graph` `create_queries` as either a simple string or a serialized JSON object. The Metabase API has accepted both shapes since 0.50.0 (`create-queries` shares the same `Schemas` union as `view-data`), but the provider was only modeling the scalar form, which caused `terraform plan` to fail with a JSON unmarshal error during state refresh whenever the server returned the object form. (Thanks @rajeshfintech!)


### PR DESCRIPTION
BUG FIXES:

- Handle `metabase_permissions_graph` `create_queries` as either a simple string or a serialized JSON object. The Metabase API has accepted both shapes since 0.50.0 (`create-queries` shares the same `Schemas` union as `view-data`), but the provider was only modeling the scalar form, which caused `terraform plan` to fail with a JSON unmarshal error during state refresh whenever the server returned the object form. (Thanks @rajeshfintech!)
