### PR TITLE
👷 Drop the windows/arm release target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:


### PR DESCRIPTION
### 📝 Description of the PR

Go 1.26 removed the 32-bit `windows/arm` port. Because the release configuration builds every combination of the listed operating systems and architectures, the release of 0.14.3 failed with `unsupported GOOS/GOARCH pair windows/arm`. That target is now explicitly excluded, like `darwin/386` already was.

No other platform is affected: `windows/arm64` is still built, and users on 32-bit Windows ARM were relying on a port Go no longer supports.

### 🐙 Related GitHub issue(s)

<!-- List the GitHub issues that should be closed thanks to this PR, e.g. "Closes #001.". -->

### 🕰️ Commits

<!-- Insert the list of commits here. (They are automatically generated when using `gh pr create`.) -->
