### PR TITLE
feat: add write-only database connection details

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -4,18 +4,25 @@ page_title: "metabase_database Resource - terraform-provider-metabase"
 subcategory: ""
 description: |-
   A database Metabase can connect to. Currently only BigQuery has a dedicated attribute, but any engine can be set up using the custom_details attribute.
-  The configuration of this resource requires passing sensitive credentials to the Metabase API. Those credentials will also be stored in the Terraform state. Ensure those values are not checked into a repository nor are being displayed during Terraform operations.
+  The configuration of this resource requires passing sensitive credentials to the Metabase API. Credentials supplied through regular attributes are stored in Terraform state. For custom details, sensitive_details_json_wo can be used with Terraform 1.11 or later to avoid storing credentials in plan or state.
 ---
 
 # metabase_database (Resource)
 
 A database Metabase can connect to. Currently only BigQuery has a dedicated attribute, but any engine can be set up using the custom_details attribute.
 
-The configuration of this resource requires passing sensitive credentials to the Metabase API. Those credentials will also be stored in the Terraform state. Ensure those values are not checked into a repository nor are being displayed during Terraform operations.
+The configuration of this resource requires passing sensitive credentials to the Metabase API. Credentials supplied through regular attributes are stored in Terraform state. For custom details, sensitive_details_json_wo can be used with Terraform 1.11 or later to avoid storing credentials in plan or state.
 
 ## Example Usage
 
 ```terraform
+variable "database_password" {
+  description = "Password used by Metabase to connect to the custom database."
+  type        = string
+  sensitive   = true
+  ephemeral   = true
+}
+
 resource "metabase_database" "bigquery" {
   name = "🗃️ Big Query"
 
@@ -53,7 +60,6 @@ resource "metabase_database" "custom" {
       port                    = 5432
       dbname                  = "database"
       user                    = "user"
-      password                = "password"
       schema-filters-type     = "inclusion"
       schema-filters-patterns = "this_schema_only"
       ssl                     = false
@@ -61,8 +67,13 @@ resource "metabase_database" "custom" {
       advanced-options        = false
     })
 
-    # Details attributes redacted by Metabase should be listed here, such that they are not incorrectly detected as a
-    # change.
+    sensitive_details_json_wo = jsonencode({
+      password = var.database_password
+    })
+    sensitive_details_json_wo_version = 1
+
+    # Detail attributes redacted by Metabase should be listed here so they are not incorrectly detected as a change.
+    # Also list attributes that are present in both JSON objects.
     redacted_attributes = [
       "password",
     ]
@@ -110,7 +121,9 @@ Required:
 
 Optional:
 
-- `redacted_attributes` (Set of String) The list of `details_json` attributes that are sent back redacted by Metabase.
+- `redacted_attributes` (Set of String) The list of database detail attributes whose values from Metabase responses should be ignored, typically because Metabase redacts them. Include any attribute present in both `details_json` and `sensitive_details_json_wo`.
+- `sensitive_details_json_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase, with values in this object taking precedence. `sensitive_details_json_wo_version` must also be set. Attributes present in both JSON objects must be included in `redacted_attributes` to prevent response values from entering state. Requires Terraform 1.11 or later.
+- `sensitive_details_json_wo_version` (Number) A non-sensitive version for `sensitive_details_json_wo` that is stored in state. Required when `sensitive_details_json_wo` is set. Increment this value to send updated sensitive details to Metabase.
 
 ## Import
 

--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -71,12 +71,6 @@ resource "metabase_database" "custom" {
       password = var.database_password
     })
     sensitive_details_json_wo_version = 1
-
-    # Detail attributes redacted by Metabase should be listed here so they are not incorrectly detected as a change.
-    # Also list attributes that are present in both JSON objects.
-    redacted_attributes = [
-      "password",
-    ]
   }
 }
 ```
@@ -121,9 +115,9 @@ Required:
 
 Optional:
 
-- `redacted_attributes` (Set of String) The list of database detail attributes whose values from Metabase responses should be ignored, typically because Metabase redacts them. Include any attribute present in both `details_json` and `sensitive_details_json_wo`.
-- `sensitive_details_json_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase, with values in this object taking precedence. `sensitive_details_json_wo_version` must also be set. Attributes present in both JSON objects must be included in `redacted_attributes` to prevent response values from entering state. Requires Terraform 1.11 or later.
-- `sensitive_details_json_wo_version` (Number) A non-sensitive version for `sensitive_details_json_wo` that is stored in state. Required when `sensitive_details_json_wo` is set. Increment this value to send updated sensitive details to Metabase.
+- `redacted_attributes` (Set of String) The list of `details_json` attributes that are sent back redacted by Metabase.
+- `sensitive_details_json_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase. Attributes must not also appear in `details_json`. `sensitive_details_json_wo_version` must also be set. Requires Terraform 1.11 or later.
+- `sensitive_details_json_wo_version` (Number) A non-sensitive version for `sensitive_details_json_wo` that is stored in state. It must be configured together with `sensitive_details_json_wo`. Increment this value to send updated sensitive details to Metabase.
 
 ## Import
 

--- a/examples/resources/metabase_database/resource.tf
+++ b/examples/resources/metabase_database/resource.tf
@@ -1,3 +1,10 @@
+variable "database_password" {
+  description = "Password used by Metabase to connect to the custom database."
+  type        = string
+  sensitive   = true
+  ephemeral   = true
+}
+
 resource "metabase_database" "bigquery" {
   name = "🗃️ Big Query"
 
@@ -35,7 +42,6 @@ resource "metabase_database" "custom" {
       port                    = 5432
       dbname                  = "database"
       user                    = "user"
-      password                = "password"
       schema-filters-type     = "inclusion"
       schema-filters-patterns = "this_schema_only"
       ssl                     = false
@@ -43,8 +49,13 @@ resource "metabase_database" "custom" {
       advanced-options        = false
     })
 
-    # Details attributes redacted by Metabase should be listed here, such that they are not incorrectly detected as a
-    # change.
+    sensitive_details_json_wo = jsonencode({
+      password = var.database_password
+    })
+    sensitive_details_json_wo_version = 1
+
+    # Detail attributes redacted by Metabase should be listed here so they are not incorrectly detected as a change.
+    # Also list attributes that are present in both JSON objects.
     redacted_attributes = [
       "password",
     ]

--- a/examples/resources/metabase_database/resource.tf
+++ b/examples/resources/metabase_database/resource.tf
@@ -53,11 +53,5 @@ resource "metabase_database" "custom" {
       password = var.database_password
     })
     sensitive_details_json_wo_version = 1
-
-    # Detail attributes redacted by Metabase should be listed here so they are not incorrectly detected as a change.
-    # Also list attributes that are present in both JSON objects.
-    redacted_attributes = [
-      "password",
-    ]
   }
 }

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	"github.com/flovouin/terraform-provider-metabase/metabase"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -18,6 +20,7 @@ import (
 
 // Ensures provider defined types fully satisfy framework interfaces.
 var _ resource.ResourceWithImportState = &DatabaseResource{}
+var _ resource.ResourceWithValidateConfig = &DatabaseResource{}
 
 // Creates a new database resource.
 func NewDatabaseResource() resource.Resource {
@@ -49,9 +52,11 @@ type BigQueryDetails struct {
 
 // The content of the `custom_details` attribute to set up a database not supported by this provider.
 type CustomDetails struct {
-	Engine             types.String `tfsdk:"engine"`              // The name of the engine, as defined by Metabase.
-	DetailsJson        types.String `tfsdk:"details_json"`        // A JSON string containing the details for the database.
-	RedactedAttributes types.Set    `tfsdk:"redacted_attributes"` // The list of `details_json` attributes that are sent back redacted by Metabase.
+	Engine                        types.String `tfsdk:"engine"`                            // The name of the engine, as defined by Metabase.
+	DetailsJson                   types.String `tfsdk:"details_json"`                      // A JSON string containing the details for the database.
+	SensitiveDetailsJsonWo        types.String `tfsdk:"sensitive_details_json_wo"`         // A write-only JSON object merged into `details_json`.
+	SensitiveDetailsJsonWoVersion types.Int64  `tfsdk:"sensitive_details_json_wo_version"` // The version used to trigger updates of `sensitive_details_json_wo`.
+	RedactedAttributes            types.Set    `tfsdk:"redacted_attributes"`               // The list of `details_json` attributes that are sent back redacted by Metabase.
 }
 
 // The object type for BigQuery details.
@@ -67,8 +72,10 @@ var bigQueryDetailsObjectType = types.ObjectType{
 // The object type for custom details.
 var customDetailsObjectType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
-		"engine":       types.StringType,
-		"details_json": types.StringType,
+		"engine":                            types.StringType,
+		"details_json":                      types.StringType,
+		"sensitive_details_json_wo":         types.StringType,
+		"sensitive_details_json_wo_version": types.Int64Type,
 		"redacted_attributes": types.SetType{
 			ElemType: types.StringType,
 		},
@@ -79,7 +86,7 @@ func (r *DatabaseResource) Schema(ctx context.Context, req resource.SchemaReques
 	resp.Schema = schema.Schema{
 		MarkdownDescription: `A database Metabase can connect to. Currently only BigQuery has a dedicated attribute, but any engine can be set up using the custom_details attribute.
 
-The configuration of this resource requires passing sensitive credentials to the Metabase API. Those credentials will also be stored in the Terraform state. Ensure those values are not checked into a repository nor are being displayed during Terraform operations.`,
+The configuration of this resource requires passing sensitive credentials to the Metabase API. Credentials supplied through regular attributes are stored in Terraform state. For custom details, sensitive_details_json_wo can be used with Terraform 1.11 or later to avoid storing credentials in plan or state.`,
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.Int64Attribute{
@@ -126,14 +133,47 @@ The configuration of this resource requires passing sensitive credentials to the
 						MarkdownDescription: "The details for the database, as a JSON string. `jsonencode` can be used for clarity.",
 						Required:            true,
 					},
+					"sensitive_details_json_wo": schema.StringAttribute{
+						MarkdownDescription: "A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase, with values in this object taking precedence. `sensitive_details_json_wo_version` must also be set. Attributes present in both JSON objects must be included in `redacted_attributes` to prevent response values from entering state. Requires Terraform 1.11 or later.",
+						Optional:            true,
+						Sensitive:           true,
+						WriteOnly:           true,
+					},
+					"sensitive_details_json_wo_version": schema.Int64Attribute{
+						MarkdownDescription: "A non-sensitive version for `sensitive_details_json_wo` that is stored in state. Required when `sensitive_details_json_wo` is set. Increment this value to send updated sensitive details to Metabase.",
+						Optional:            true,
+					},
 					"redacted_attributes": schema.SetAttribute{
 						ElementType:         types.StringType,
-						MarkdownDescription: "The list of `details_json` attributes that are sent back redacted by Metabase.",
+						MarkdownDescription: "The list of database detail attributes whose values from Metabase responses should be ignored, typically because Metabase redacts them. Include any attribute present in both `details_json` and `sensitive_details_json_wo`.",
 						Optional:            true,
 					},
 				},
 			},
 		},
+	}
+}
+
+func (r *DatabaseResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data DatabaseResourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.CustomDetails.IsNull() || data.CustomDetails.IsUnknown() {
+		return
+	}
+
+	var customDetails CustomDetails
+	resp.Diagnostics.Append(data.CustomDetails.As(ctx, &customDetails, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() || customDetails.SensitiveDetailsJsonWo.IsNull() || customDetails.SensitiveDetailsJsonWo.IsUnknown() {
+		return
+	}
+
+	if customDetails.SensitiveDetailsJsonWoVersion.IsNull() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("custom_details").AtName("sensitive_details_json_wo_version"),
+			"Missing sensitive details version",
+			"sensitive_details_json_wo_version must be set when sensitive_details_json_wo is configured. Increment the version whenever the sensitive details change.",
+		)
 	}
 }
 
@@ -192,6 +232,7 @@ func makeCustomDetailsFromResponseBody(ctx context.Context, db metabase.Database
 	var detailsJson string
 	var existingDetails map[string]any
 	redactedAttributesValue := types.SetNull(types.StringType)
+	sensitiveDetailsJsonWoVersionValue := types.Int64Null()
 	if !data.CustomDetails.IsNull() {
 		var cd CustomDetails
 		diags.Append(data.CustomDetails.As(ctx, &cd, basetypes.ObjectAsOptions{})...)
@@ -200,6 +241,7 @@ func makeCustomDetailsFromResponseBody(ctx context.Context, db metabase.Database
 		}
 
 		redactedAttributesValue = cd.RedactedAttributes
+		sensitiveDetailsJsonWoVersionValue = cd.SensitiveDetailsJsonWoVersion
 		var redactedAttributes []string
 		if !cd.RedactedAttributes.IsNull() {
 			diags.Append(cd.RedactedAttributes.ElementsAs(ctx, &redactedAttributes, false)...)
@@ -249,9 +291,11 @@ func makeCustomDetailsFromResponseBody(ctx context.Context, db metabase.Database
 	}
 
 	details, objectDiags := types.ObjectValue(customDetailsObjectType.AttrTypes, map[string]attr.Value{
-		"engine":              types.StringValue(engine),
-		"details_json":        types.StringValue(detailsJson),
-		"redacted_attributes": redactedAttributesValue,
+		"engine":                            types.StringValue(engine),
+		"details_json":                      types.StringValue(detailsJson),
+		"sensitive_details_json_wo":         types.StringNull(),
+		"sensitive_details_json_wo_version": sensitiveDetailsJsonWoVersionValue,
+		"redacted_attributes":               redactedAttributesValue,
 	})
 	diags.Append(objectDiags...)
 	if diags.HasError() {
@@ -302,7 +346,7 @@ type DatabaseEngineAndDetails struct {
 }
 
 // Converts a `DatabaseResourceModel` to a `DatabaseEngineAndDetails` that can be used to make requests against the database API.
-func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceModel) (*DatabaseEngineAndDetails, diag.Diagnostics) {
+func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceModel, configuredCustomDetails types.Object) (*DatabaseEngineAndDetails, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	var engine metabase.DatabaseEngine
@@ -343,6 +387,55 @@ func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceMod
 			return nil, diags
 		}
 
+		if !configuredCustomDetails.IsNull() {
+			var configuredCd CustomDetails
+			diags.Append(configuredCustomDetails.As(ctx, &configuredCd, basetypes.ObjectAsOptions{})...)
+			if diags.HasError() {
+				return nil, diags
+			}
+
+			if !configuredCd.SensitiveDetailsJsonWo.IsNull() {
+				var sensitiveRawDetails map[string]any
+				err = json.Unmarshal([]byte(configuredCd.SensitiveDetailsJsonWo.ValueString()), &sensitiveRawDetails)
+				if err != nil {
+					diags.AddError("Unable to deserialize sensitive_details_json_wo as an object.", err.Error())
+					return nil, diags
+				}
+				if sensitiveRawDetails == nil {
+					diags.AddError("Unable to deserialize sensitive_details_json_wo as an object.", "The JSON value must be an object, not null.")
+					return nil, diags
+				}
+				if rawDetails == nil {
+					rawDetails = make(map[string]any)
+				}
+
+				redactedAttributes := make(map[string]struct{})
+				if !cd.RedactedAttributes.IsNull() {
+					var attributes []string
+					diags.Append(cd.RedactedAttributes.ElementsAs(ctx, &attributes, false)...)
+					if diags.HasError() {
+						return nil, diags
+					}
+					for _, attribute := range attributes {
+						redactedAttributes[attribute] = struct{}{}
+					}
+				}
+
+				for attribute, value := range sensitiveRawDetails {
+					if _, existsInDetails := rawDetails[attribute]; existsInDetails {
+						if _, isRedacted := redactedAttributes[attribute]; !isRedacted {
+							diags.AddError(
+								"Sensitive detail is also present in details_json.",
+								fmt.Sprintf("Attribute %q must either be removed from details_json or included in redacted_attributes to prevent its sensitive value from being stored in state.", attribute),
+							)
+							return nil, diags
+						}
+					}
+					rawDetails[attribute] = value
+				}
+			}
+		}
+
 		err = details.FromDatabaseDetailsCustom(rawDetails)
 		if err != nil {
 			diags.AddError("Failed to prepare database payload from Terraform model.", err.Error())
@@ -364,13 +457,18 @@ func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceMod
 
 func (r *DatabaseResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data *DatabaseResourceModel
+	var config *DatabaseResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	engineAndDetails, diags := makeEngineAndDetailsFromModel(ctx, *data)
+	engineAndDetails, diags := makeEngineAndDetailsFromModel(ctx, *data, config.CustomDetails)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -426,8 +524,13 @@ func (r *DatabaseResource) Read(ctx context.Context, req resource.ReadRequest, r
 func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data *DatabaseResourceModel
 	var state *DatabaseResourceModel
+	var config *DatabaseResourceModel
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -443,7 +546,7 @@ func (r *DatabaseResource) Update(ctx context.Context, req resource.UpdateReques
 	// Only updating database details if they have changed. This avoids unnecessarily passing credentials in API calls.
 	if !state.BigQueryDetails.Equal(data.BigQueryDetails) ||
 		!state.CustomDetails.Equal(data.CustomDetails) {
-		engineAndDetails, diags := makeEngineAndDetailsFromModel(ctx, *data)
+		engineAndDetails, diags := makeEngineAndDetailsFromModel(ctx, *data, config.CustomDetails)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -134,24 +134,93 @@ The configuration of this resource requires passing sensitive credentials to the
 						Required:            true,
 					},
 					"sensitive_details_json_wo": schema.StringAttribute{
-						MarkdownDescription: "A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase, with values in this object taking precedence. `sensitive_details_json_wo_version` must also be set. Attributes present in both JSON objects must be included in `redacted_attributes` to prevent response values from entering state. Requires Terraform 1.11 or later.",
+						MarkdownDescription: "A write-only JSON object containing sensitive details. Its attributes are merged into `details_json` before requests are sent to Metabase. Attributes must not also appear in `details_json`. `sensitive_details_json_wo_version` must also be set. Requires Terraform 1.11 or later.",
 						Optional:            true,
 						Sensitive:           true,
 						WriteOnly:           true,
 					},
 					"sensitive_details_json_wo_version": schema.Int64Attribute{
-						MarkdownDescription: "A non-sensitive version for `sensitive_details_json_wo` that is stored in state. Required when `sensitive_details_json_wo` is set. Increment this value to send updated sensitive details to Metabase.",
+						MarkdownDescription: "A non-sensitive version for `sensitive_details_json_wo` that is stored in state. It must be configured together with `sensitive_details_json_wo`. Increment this value to send updated sensitive details to Metabase.",
 						Optional:            true,
 					},
 					"redacted_attributes": schema.SetAttribute{
 						ElementType:         types.StringType,
-						MarkdownDescription: "The list of database detail attributes whose values from Metabase responses should be ignored, typically because Metabase redacts them. Include any attribute present in both `details_json` and `sensitive_details_json_wo`.",
+						MarkdownDescription: "The list of `details_json` attributes that are sent back redacted by Metabase.",
 						Optional:            true,
 					},
 				},
 			},
 		},
 	}
+}
+
+func validateCustomDetails(customDetails CustomDetails) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	sensitiveDetailsConfigured := !customDetails.SensitiveDetailsJsonWo.IsNull()
+	sensitiveDetailsVersionConfigured := !customDetails.SensitiveDetailsJsonWoVersion.IsNull()
+
+	if sensitiveDetailsConfigured && !sensitiveDetailsVersionConfigured {
+		diags.AddAttributeError(
+			path.Root("custom_details").AtName("sensitive_details_json_wo_version"),
+			"Missing sensitive details version",
+			"sensitive_details_json_wo_version must be set when sensitive_details_json_wo is configured. Increment the version whenever the sensitive details change.",
+		)
+		return diags
+	}
+	if !sensitiveDetailsConfigured && sensitiveDetailsVersionConfigured {
+		diags.AddAttributeError(
+			path.Root("custom_details").AtName("sensitive_details_json_wo"),
+			"Missing sensitive details",
+			"sensitive_details_json_wo must be set when sensitive_details_json_wo_version is configured.",
+		)
+		return diags
+	}
+
+	if !sensitiveDetailsConfigured || customDetails.DetailsJson.IsUnknown() || customDetails.SensitiveDetailsJsonWo.IsUnknown() {
+		return diags
+	}
+
+	var rawDetails map[string]any
+	if err := json.Unmarshal([]byte(customDetails.DetailsJson.ValueString()), &rawDetails); err != nil {
+		diags.AddAttributeError(
+			path.Root("custom_details").AtName("details_json"),
+			"Unable to deserialize details_json as an object",
+			err.Error(),
+		)
+		return diags
+	}
+
+	var sensitiveRawDetails map[string]any
+	if err := json.Unmarshal([]byte(customDetails.SensitiveDetailsJsonWo.ValueString()), &sensitiveRawDetails); err != nil {
+		diags.AddAttributeError(
+			path.Root("custom_details").AtName("sensitive_details_json_wo"),
+			"Unable to deserialize sensitive_details_json_wo as an object",
+			err.Error(),
+		)
+		return diags
+	}
+	if sensitiveRawDetails == nil {
+		diags.AddAttributeError(
+			path.Root("custom_details").AtName("sensitive_details_json_wo"),
+			"Unable to deserialize sensitive_details_json_wo as an object",
+			"The JSON value must be an object, not null.",
+		)
+		return diags
+	}
+
+	for attribute := range sensitiveRawDetails {
+		if _, exists := rawDetails[attribute]; exists {
+			diags.AddAttributeError(
+				path.Root("custom_details").AtName("sensitive_details_json_wo"),
+				"Database detail is configured more than once",
+				fmt.Sprintf("Attribute %q must be configured in either details_json or sensitive_details_json_wo, not both.", attribute),
+			)
+			return diags
+		}
+	}
+
+	return diags
 }
 
 func (r *DatabaseResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
@@ -164,17 +233,11 @@ func (r *DatabaseResource) ValidateConfig(ctx context.Context, req resource.Vali
 
 	var customDetails CustomDetails
 	resp.Diagnostics.Append(data.CustomDetails.As(ctx, &customDetails, basetypes.ObjectAsOptions{})...)
-	if resp.Diagnostics.HasError() || customDetails.SensitiveDetailsJsonWo.IsNull() || customDetails.SensitiveDetailsJsonWo.IsUnknown() {
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if customDetails.SensitiveDetailsJsonWoVersion.IsNull() {
-		resp.Diagnostics.AddAttributeError(
-			path.Root("custom_details").AtName("sensitive_details_json_wo_version"),
-			"Missing sensitive details version",
-			"sensitive_details_json_wo_version must be set when sensitive_details_json_wo is configured. Increment the version whenever the sensitive details change.",
-		)
-	}
+	resp.Diagnostics.Append(validateCustomDetails(customDetails)...)
 }
 
 // Makes the Terraform object for the `bigquery_details` field.
@@ -393,6 +456,10 @@ func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceMod
 			if diags.HasError() {
 				return nil, diags
 			}
+			diags.Append(validateCustomDetails(configuredCd)...)
+			if diags.HasError() {
+				return nil, diags
+			}
 
 			if !configuredCd.SensitiveDetailsJsonWo.IsNull() {
 				var sensitiveRawDetails map[string]any
@@ -401,36 +468,11 @@ func makeEngineAndDetailsFromModel(ctx context.Context, data DatabaseResourceMod
 					diags.AddError("Unable to deserialize sensitive_details_json_wo as an object.", err.Error())
 					return nil, diags
 				}
-				if sensitiveRawDetails == nil {
-					diags.AddError("Unable to deserialize sensitive_details_json_wo as an object.", "The JSON value must be an object, not null.")
-					return nil, diags
-				}
 				if rawDetails == nil {
 					rawDetails = make(map[string]any)
 				}
 
-				redactedAttributes := make(map[string]struct{})
-				if !cd.RedactedAttributes.IsNull() {
-					var attributes []string
-					diags.Append(cd.RedactedAttributes.ElementsAs(ctx, &attributes, false)...)
-					if diags.HasError() {
-						return nil, diags
-					}
-					for _, attribute := range attributes {
-						redactedAttributes[attribute] = struct{}{}
-					}
-				}
-
 				for attribute, value := range sensitiveRawDetails {
-					if _, existsInDetails := rawDetails[attribute]; existsInDetails {
-						if _, isRedacted := redactedAttributes[attribute]; !isRedacted {
-							diags.AddError(
-								"Sensitive detail is also present in details_json.",
-								fmt.Sprintf("Attribute %q must either be removed from details_json or included in redacted_attributes to prevent its sensitive value from being stored in state.", attribute),
-							)
-							return nil, diags
-						}
-					}
 					rawDetails[attribute] = value
 				}
 			}

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -41,7 +41,6 @@ func TestMakeEngineAndDetailsFromModelCustomDetails(t *testing.T) {
 
 	tests := map[string]struct {
 		sensitiveDetailsJsonWo types.String
-		redactedAttributes     []string
 		expected               map[string]any
 	}{
 		"legacy details_json": {
@@ -51,11 +50,10 @@ func TestMakeEngineAndDetailsFromModelCustomDetails(t *testing.T) {
 				"port": float64(5432),
 			},
 		},
-		"write-only details override regular details": {
-			sensitiveDetailsJsonWo: types.StringValue(`{"host":"secret.example.internal","password":"secret"}`),
-			redactedAttributes:     []string{"host"},
+		"write-only details are merged with regular details": {
+			sensitiveDetailsJsonWo: types.StringValue(`{"password":"secret"}`),
 			expected: map[string]any{
-				"host":     "secret.example.internal",
+				"host":     "postgres.example.internal",
 				"port":     float64(5432),
 				"password": "secret",
 			},
@@ -66,19 +64,22 @@ func TestMakeEngineAndDetailsFromModelCustomDetails(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
+			sensitiveDetailsVersion := types.Int64Null()
+			if !test.sensitiveDetailsJsonWo.IsNull() {
+				sensitiveDetailsVersion = types.Int64Value(1)
+			}
+
 			data := DatabaseResourceModel{
 				CustomDetails: testCustomDetailsValue(
 					`{"host":"postgres.example.internal","port":5432}`,
 					types.StringNull(),
-					types.Int64Value(1),
-					test.redactedAttributes...,
+					sensitiveDetailsVersion,
 				),
 			}
 			configuredCustomDetails := testCustomDetailsValue(
 				`{"host":"postgres.example.internal","port":5432}`,
 				test.sensitiveDetailsJsonWo,
-				types.Int64Value(1),
-				test.redactedAttributes...,
+				sensitiveDetailsVersion,
 			)
 
 			engineAndDetails, diags := makeEngineAndDetailsFromModel(context.Background(), data, configuredCustomDetails)
@@ -97,24 +98,25 @@ func TestMakeEngineAndDetailsFromModelCustomDetails(t *testing.T) {
 	}
 }
 
-func TestMakeEngineAndDetailsFromModelRejectsUnredactedOverlap(t *testing.T) {
+func TestMakeEngineAndDetailsFromModelRejectsOverlap(t *testing.T) {
 	t.Parallel()
 
 	data := DatabaseResourceModel{
-		CustomDetails: testCustomDetailsValue(`{"host":"postgres.example.internal"}`, types.StringNull(), types.Int64Value(1)),
+		CustomDetails: testCustomDetailsValue(`{"host":"postgres.example.internal"}`, types.StringNull(), types.Int64Value(1), "host"),
 	}
 	configuredCustomDetails := testCustomDetailsValue(
 		`{"host":"postgres.example.internal"}`,
 		types.StringValue(`{"host":"secret.example.internal"}`),
 		types.Int64Value(1),
+		"host",
 	)
 
 	engineAndDetails, diags := makeEngineAndDetailsFromModel(context.Background(), data, configuredCustomDetails)
 	if engineAndDetails != nil {
-		t.Fatalf("Expected no database details for an unredacted overlapping attribute, got %#v", engineAndDetails)
+		t.Fatalf("Expected no database details for an overlapping attribute, got %#v", engineAndDetails)
 	}
 	if !diags.HasError() {
-		t.Fatal("Expected an error diagnostic for an unredacted overlapping attribute")
+		t.Fatal("Expected an error diagnostic for an overlapping attribute")
 	}
 }
 
@@ -144,7 +146,7 @@ func TestMakeCustomDetailsFromResponseBodyOmitsSensitiveDetails(t *testing.T) {
 
 	var databaseDetails metabase.DatabaseDetails
 	err := databaseDetails.FromDatabaseDetailsCustom(map[string]any{
-		"host":     "secret.example.internal",
+		"host":     "postgres.example.internal",
 		"password": "**MetabasePass**",
 	})
 	if err != nil {
@@ -156,7 +158,6 @@ func TestMakeCustomDetailsFromResponseBodyOmitsSensitiveDetails(t *testing.T) {
 			`{"host":"postgres.example.internal"}`,
 			types.StringNull(),
 			types.Int64Value(7),
-			"host",
 		),
 	}
 	details, diags := makeCustomDetailsFromResponseBody(context.Background(), metabase.Database{
@@ -180,9 +181,6 @@ func TestMakeCustomDetailsFromResponseBodyOmitsSensitiveDetails(t *testing.T) {
 	if _, exists := storedDetails["password"]; exists {
 		t.Fatalf("Sensitive detail was retained in state details: %#v", storedDetails)
 	}
-	if storedDetails["host"] != "postgres.example.internal" {
-		t.Fatalf("Sensitive overlapping detail replaced the configured state value: %#v", storedDetails)
-	}
 	if !actual.SensitiveDetailsJsonWo.IsNull() {
 		t.Fatalf("Write-only details must be null in state, got %q", actual.SensitiveDetailsJsonWo.ValueString())
 	}
@@ -191,10 +189,152 @@ func TestMakeCustomDetailsFromResponseBodyOmitsSensitiveDetails(t *testing.T) {
 	}
 }
 
+func TestMakeCustomDetailsFromResponseBodyPreservesRedactedDetails(t *testing.T) {
+	t.Parallel()
+
+	var databaseDetails metabase.DatabaseDetails
+	err := databaseDetails.FromDatabaseDetailsCustom(map[string]any{
+		"host":     "postgres.example.internal",
+		"password": "**MetabasePass**",
+	})
+	if err != nil {
+		t.Fatalf("Failed to prepare API database details: %v", err)
+	}
+
+	data := DatabaseResourceModel{
+		CustomDetails: testCustomDetailsValue(
+			`{"host":"postgres.example.internal","password":"secret"}`,
+			types.StringNull(),
+			types.Int64Null(),
+			"password",
+		),
+	}
+	details, diags := makeCustomDetailsFromResponseBody(context.Background(), metabase.Database{
+		Engine:  metabase.DatabaseEngine("postgres"),
+		Details: databaseDetails,
+	}, &data)
+	if diags.HasError() {
+		t.Fatalf("Unexpected diagnostics: %v", diags)
+	}
+
+	var actual CustomDetails
+	diags = details.As(context.Background(), &actual, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		t.Fatalf("Failed to read Terraform custom details: %v", diags)
+	}
+
+	var storedDetails map[string]any
+	if err := json.Unmarshal([]byte(actual.DetailsJson.ValueString()), &storedDetails); err != nil {
+		t.Fatalf("Failed to read stored details_json: %v", err)
+	}
+	if storedDetails["password"] != "secret" {
+		t.Fatalf("Redacted detail was not preserved in state: %#v", storedDetails)
+	}
+}
+
+func TestValidateCustomDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		customDetails CustomDetails
+		expectError   bool
+	}{
+		"legacy details": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringNull(),
+				SensitiveDetailsJsonWoVersion: types.Int64Null(),
+			},
+		},
+		"write-only details and version": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringValue(`{"password":"secret"}`),
+				SensitiveDetailsJsonWoVersion: types.Int64Value(1),
+			},
+		},
+		"unknown details defer overlap validation": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringUnknown(),
+				SensitiveDetailsJsonWo:        types.StringValue(`{"password":"secret"}`),
+				SensitiveDetailsJsonWoVersion: types.Int64Value(1),
+			},
+		},
+		"unknown write-only details defer overlap validation": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringUnknown(),
+				SensitiveDetailsJsonWoVersion: types.Int64Value(1),
+			},
+		},
+		"write-only details without version": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringValue(`{"password":"secret"}`),
+				SensitiveDetailsJsonWoVersion: types.Int64Null(),
+			},
+			expectError: true,
+		},
+		"version without write-only details": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringNull(),
+				SensitiveDetailsJsonWoVersion: types.Int64Value(1),
+			},
+			expectError: true,
+		},
+		"overlapping details": {
+			customDetails: CustomDetails{
+				DetailsJson:                   types.StringValue(`{"host":"postgres.example.internal"}`),
+				SensitiveDetailsJsonWo:        types.StringValue(`{"host":"secret.example.internal"}`),
+				SensitiveDetailsJsonWoVersion: types.Int64Value(1),
+				RedactedAttributes:            types.SetValueMust(types.StringType, []attr.Value{types.StringValue("host")}),
+			},
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := validateCustomDetails(test.customDetails)
+			if diags.HasError() != test.expectError {
+				t.Fatalf("Unexpected validation diagnostics: %v", diags)
+			}
+		})
+	}
+}
+
 func testAccDatabaseResource(name string, dbName string, sensitiveDetailsVersion int) string {
 	return fmt.Sprintf(`
 resource "metabase_database" "%s" {
   name = "%s"
+
+  custom_details = {
+    engine = "postgres"
+
+    details_json = jsonencode({
+      host                    = "%s"
+      port                    = 5432
+      dbname                  = "%s"
+      user                    = "%s"
+      password                = "%s"
+      schema-filters-type     = "inclusion"
+      schema-filters-patterns = "this_schema_only"
+      ssl                     = false
+      tunnel-enabled          = false
+      advanced-options        = false
+    })
+
+    redacted_attributes = [
+      "password",
+    ]
+  }
+}
+
+resource "metabase_database" "%s_write_only" {
+  name = "%s write-only"
 
   custom_details = {
     engine = "postgres"
@@ -215,13 +355,15 @@ resource "metabase_database" "%s" {
       password = "%s"
     })
     sensitive_details_json_wo_version = %d
-
-    redacted_attributes = [
-      "password",
-    ]
   }
 }
 `,
+		name,
+		dbName,
+		os.Getenv("PG_HOST"),
+		os.Getenv("PG_DATABASE"),
+		os.Getenv("PG_USER"),
+		os.Getenv("PG_PASSWORD"),
 		name,
 		dbName,
 		os.Getenv("PG_HOST"),
@@ -240,6 +382,22 @@ func testAccCheckDatabaseDetailNotStored(resourceName string, detailName string)
 		}
 		if _, exists := details[detailName]; exists {
 			return fmt.Errorf("Database detail %q was unexpectedly stored in state.", detailName)
+		}
+
+		return nil
+	})
+}
+
+func testAccCheckDatabaseDetailStored(resourceName string, detailName string, expectedValue string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(resourceName, "custom_details.details_json", func(value string) error {
+		var details map[string]any
+		if err := json.Unmarshal([]byte(value), &details); err != nil {
+			return fmt.Errorf("Failed to deserialize custom database details from state: %w", err)
+		}
+		if detailValue, exists := details[detailName]; !exists {
+			return fmt.Errorf("Database detail %q was unexpectedly missing from state.", detailName)
+		} else if detailValue != expectedValue {
+			return fmt.Errorf("Database detail %q did not retain its configured value: got %#v, expected %#v.", detailName, detailValue, expectedValue)
 		}
 
 		return nil
@@ -306,13 +464,22 @@ func TestAccDatabaseResource(t *testing.T) {
 				Config: providerConfig + testAccDatabaseResource("test", "🐘 PG", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDatabaseExists("metabase_database.test"),
-					testAccCheckDatabaseDetailNotStored("metabase_database.test", "password"),
+					testAccCheckDatabaseDetailStored("metabase_database.test", "password", os.Getenv("PG_PASSWORD")),
 					resource.TestCheckResourceAttrSet("metabase_database.test", "id"),
 					resource.TestCheckResourceAttr("metabase_database.test", "name", "🐘 PG"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "bigquery_details"),
 					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.engine", "postgres"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo"),
-					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version"),
+					testAccCheckDatabaseExists("metabase_database.test_write_only"),
+					testAccCheckDatabaseDetailNotStored("metabase_database.test_write_only", "password"),
+					resource.TestCheckResourceAttrSet("metabase_database.test_write_only", "id"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "name", "🐘 PG write-only"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "bigquery_details"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "custom_details.engine", "postgres"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "custom_details.sensitive_details_json_wo"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "custom_details.sensitive_details_json_wo_version", "1"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "custom_details.redacted_attributes"),
 				),
 			},
 			{
@@ -322,13 +489,21 @@ func TestAccDatabaseResource(t *testing.T) {
 			{
 				Config: providerConfig + testAccDatabaseResource("test", "✨ New", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDatabaseDetailNotStored("metabase_database.test", "password"),
+					testAccCheckDatabaseDetailStored("metabase_database.test", "password", os.Getenv("PG_PASSWORD")),
 					resource.TestCheckResourceAttrSet("metabase_database.test", "id"),
 					resource.TestCheckResourceAttr("metabase_database.test", "name", "✨ New"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "bigquery_details"),
 					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.engine", "postgres"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo"),
-					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version"),
+					testAccCheckDatabaseDetailNotStored("metabase_database.test_write_only", "password"),
+					resource.TestCheckResourceAttrSet("metabase_database.test_write_only", "id"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "name", "✨ New write-only"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "bigquery_details"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "custom_details.engine", "postgres"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "custom_details.sensitive_details_json_wo"),
+					resource.TestCheckResourceAttr("metabase_database.test_write_only", "custom_details.sensitive_details_json_wo_version", "2"),
+					resource.TestCheckNoResourceAttr("metabase_database.test_write_only", "custom_details.redacted_attributes"),
 				),
 			},
 		},

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -2,16 +2,196 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strconv"
 	"testing"
 
+	"github.com/flovouin/terraform-provider-metabase/metabase"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-func testAccDatabaseResource(name string, dbName string) string {
+func testCustomDetailsValue(detailsJson string, sensitiveDetailsJsonWo types.String, sensitiveDetailsJsonWoVersion types.Int64, redactedAttributes ...string) types.Object {
+	redactedAttributesValue := types.SetNull(types.StringType)
+	if len(redactedAttributes) > 0 {
+		attributeValues := make([]attr.Value, 0, len(redactedAttributes))
+		for _, attribute := range redactedAttributes {
+			attributeValues = append(attributeValues, types.StringValue(attribute))
+		}
+		redactedAttributesValue = types.SetValueMust(types.StringType, attributeValues)
+	}
+
+	return types.ObjectValueMust(customDetailsObjectType.AttrTypes, map[string]attr.Value{
+		"engine":                            types.StringValue("postgres"),
+		"details_json":                      types.StringValue(detailsJson),
+		"sensitive_details_json_wo":         sensitiveDetailsJsonWo,
+		"sensitive_details_json_wo_version": sensitiveDetailsJsonWoVersion,
+		"redacted_attributes":               redactedAttributesValue,
+	})
+}
+
+func TestMakeEngineAndDetailsFromModelCustomDetails(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		sensitiveDetailsJsonWo types.String
+		redactedAttributes     []string
+		expected               map[string]any
+	}{
+		"legacy details_json": {
+			sensitiveDetailsJsonWo: types.StringNull(),
+			expected: map[string]any{
+				"host": "postgres.example.internal",
+				"port": float64(5432),
+			},
+		},
+		"write-only details override regular details": {
+			sensitiveDetailsJsonWo: types.StringValue(`{"host":"secret.example.internal","password":"secret"}`),
+			redactedAttributes:     []string{"host"},
+			expected: map[string]any{
+				"host":     "secret.example.internal",
+				"port":     float64(5432),
+				"password": "secret",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			data := DatabaseResourceModel{
+				CustomDetails: testCustomDetailsValue(
+					`{"host":"postgres.example.internal","port":5432}`,
+					types.StringNull(),
+					types.Int64Value(1),
+					test.redactedAttributes...,
+				),
+			}
+			configuredCustomDetails := testCustomDetailsValue(
+				`{"host":"postgres.example.internal","port":5432}`,
+				test.sensitiveDetailsJsonWo,
+				types.Int64Value(1),
+				test.redactedAttributes...,
+			)
+
+			engineAndDetails, diags := makeEngineAndDetailsFromModel(context.Background(), data, configuredCustomDetails)
+			if diags.HasError() {
+				t.Fatalf("Unexpected diagnostics: %v", diags)
+			}
+
+			actual, err := engineAndDetails.Details.AsDatabaseDetailsCustom()
+			if err != nil {
+				t.Fatalf("Failed to read custom database details: %v", err)
+			}
+			if !reflect.DeepEqual(map[string]any(actual), test.expected) {
+				t.Fatalf("Unexpected custom database details: got %#v, expected %#v", actual, test.expected)
+			}
+		})
+	}
+}
+
+func TestMakeEngineAndDetailsFromModelRejectsUnredactedOverlap(t *testing.T) {
+	t.Parallel()
+
+	data := DatabaseResourceModel{
+		CustomDetails: testCustomDetailsValue(`{"host":"postgres.example.internal"}`, types.StringNull(), types.Int64Value(1)),
+	}
+	configuredCustomDetails := testCustomDetailsValue(
+		`{"host":"postgres.example.internal"}`,
+		types.StringValue(`{"host":"secret.example.internal"}`),
+		types.Int64Value(1),
+	)
+
+	engineAndDetails, diags := makeEngineAndDetailsFromModel(context.Background(), data, configuredCustomDetails)
+	if engineAndDetails != nil {
+		t.Fatalf("Expected no database details for an unredacted overlapping attribute, got %#v", engineAndDetails)
+	}
+	if !diags.HasError() {
+		t.Fatal("Expected an error diagnostic for an unredacted overlapping attribute")
+	}
+}
+
+func TestMakeEngineAndDetailsFromModelRejectsInvalidSensitiveDetails(t *testing.T) {
+	t.Parallel()
+
+	data := DatabaseResourceModel{
+		CustomDetails: testCustomDetailsValue(`{"host":"postgres.example.internal"}`, types.StringNull(), types.Int64Value(1)),
+	}
+	configuredCustomDetails := testCustomDetailsValue(
+		`{"host":"postgres.example.internal"}`,
+		types.StringValue(`[]`),
+		types.Int64Value(1),
+	)
+
+	engineAndDetails, diags := makeEngineAndDetailsFromModel(context.Background(), data, configuredCustomDetails)
+	if engineAndDetails != nil {
+		t.Fatalf("Expected no database details for an invalid sensitive JSON object, got %#v", engineAndDetails)
+	}
+	if !diags.HasError() {
+		t.Fatal("Expected an error diagnostic for an invalid sensitive JSON object")
+	}
+}
+
+func TestMakeCustomDetailsFromResponseBodyOmitsSensitiveDetails(t *testing.T) {
+	t.Parallel()
+
+	var databaseDetails metabase.DatabaseDetails
+	err := databaseDetails.FromDatabaseDetailsCustom(map[string]any{
+		"host":     "secret.example.internal",
+		"password": "**MetabasePass**",
+	})
+	if err != nil {
+		t.Fatalf("Failed to prepare API database details: %v", err)
+	}
+
+	data := DatabaseResourceModel{
+		CustomDetails: testCustomDetailsValue(
+			`{"host":"postgres.example.internal"}`,
+			types.StringNull(),
+			types.Int64Value(7),
+			"host",
+		),
+	}
+	details, diags := makeCustomDetailsFromResponseBody(context.Background(), metabase.Database{
+		Engine:  metabase.DatabaseEngine("postgres"),
+		Details: databaseDetails,
+	}, &data)
+	if diags.HasError() {
+		t.Fatalf("Unexpected diagnostics: %v", diags)
+	}
+
+	var actual CustomDetails
+	diags = details.As(context.Background(), &actual, basetypes.ObjectAsOptions{})
+	if diags.HasError() {
+		t.Fatalf("Failed to read Terraform custom details: %v", diags)
+	}
+
+	var storedDetails map[string]any
+	if err := json.Unmarshal([]byte(actual.DetailsJson.ValueString()), &storedDetails); err != nil {
+		t.Fatalf("Failed to read stored details_json: %v", err)
+	}
+	if _, exists := storedDetails["password"]; exists {
+		t.Fatalf("Sensitive detail was retained in state details: %#v", storedDetails)
+	}
+	if storedDetails["host"] != "postgres.example.internal" {
+		t.Fatalf("Sensitive overlapping detail replaced the configured state value: %#v", storedDetails)
+	}
+	if !actual.SensitiveDetailsJsonWo.IsNull() {
+		t.Fatalf("Write-only details must be null in state, got %q", actual.SensitiveDetailsJsonWo.ValueString())
+	}
+	if actual.SensitiveDetailsJsonWoVersion.ValueInt64() != 7 {
+		t.Fatalf("Write-only details version was not retained in state: got %d", actual.SensitiveDetailsJsonWoVersion.ValueInt64())
+	}
+}
+
+func testAccDatabaseResource(name string, dbName string, sensitiveDetailsVersion int) string {
 	return fmt.Sprintf(`
 resource "metabase_database" "%s" {
   name = "%s"
@@ -24,13 +204,17 @@ resource "metabase_database" "%s" {
       port                    = 5432
       dbname                  = "%s"
       user                    = "%s"
-      password                = "%s"
       schema-filters-type     = "inclusion"
       schema-filters-patterns = "this_schema_only"
       ssl                     = false
       tunnel-enabled          = false
       advanced-options        = false
     })
+
+    sensitive_details_json_wo = jsonencode({
+      password = "%s"
+    })
+    sensitive_details_json_wo_version = %d
 
     redacted_attributes = [
       "password",
@@ -44,7 +228,22 @@ resource "metabase_database" "%s" {
 		os.Getenv("PG_DATABASE"),
 		os.Getenv("PG_USER"),
 		os.Getenv("PG_PASSWORD"),
+		sensitiveDetailsVersion,
 	)
+}
+
+func testAccCheckDatabaseDetailNotStored(resourceName string, detailName string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(resourceName, "custom_details.details_json", func(value string) error {
+		var details map[string]any
+		if err := json.Unmarshal([]byte(value), &details); err != nil {
+			return fmt.Errorf("Failed to deserialize custom database details from state: %w", err)
+		}
+		if _, exists := details[detailName]; exists {
+			return fmt.Errorf("Database detail %q was unexpectedly stored in state.", detailName)
+		}
+
+		return nil
+	})
 }
 
 func testAccCheckDatabaseExists(resourceName string) resource.TestCheckFunc {
@@ -104,13 +303,16 @@ func TestAccDatabaseResource(t *testing.T) {
 		CheckDestroy:             testAccCheckDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + testAccDatabaseResource("test", "🐘 PG"),
+				Config: providerConfig + testAccDatabaseResource("test", "🐘 PG", 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDatabaseExists("metabase_database.test"),
+					testAccCheckDatabaseDetailNotStored("metabase_database.test", "password"),
 					resource.TestCheckResourceAttrSet("metabase_database.test", "id"),
 					resource.TestCheckResourceAttr("metabase_database.test", "name", "🐘 PG"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "bigquery_details"),
 					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.engine", "postgres"),
+					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo"),
+					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version", "1"),
 				),
 			},
 			{
@@ -118,12 +320,15 @@ func TestAccDatabaseResource(t *testing.T) {
 				ImportState:  true,
 			},
 			{
-				Config: providerConfig + testAccDatabaseResource("test", "✨ New"),
+				Config: providerConfig + testAccDatabaseResource("test", "✨ New", 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckDatabaseDetailNotStored("metabase_database.test", "password"),
 					resource.TestCheckResourceAttrSet("metabase_database.test", "id"),
 					resource.TestCheckResourceAttr("metabase_database.test", "name", "✨ New"),
 					resource.TestCheckNoResourceAttr("metabase_database.test", "bigquery_details"),
 					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.engine", "postgres"),
+					resource.TestCheckNoResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo"),
+					resource.TestCheckResourceAttr("metabase_database.test", "custom_details.sensitive_details_json_wo_version", "2"),
 				),
 			},
 		},


### PR DESCRIPTION
### 📝 Description of the PR

Adds support for securely configuring secret connection attributes on the metabase_database resource using Terraform 1.11+ write-only arguments.

- Adds custom_details.sensitive_details_json_wo, a write-only JSON object merged into details_json before requests are sent to Metabase.
- Adds sensitive_details_json_wo_version to trigger updates when credentials rotate.
- Ensures write-only values are never persisted in plans or state.
- Preserves support for existing details_json configurations.
- Validates version usage and protects overlapping attributes from leaking into state.
- Updates tests, documentation, and examples.

### 🐙 Related GitHub issue(s)

fixes #120 

### 🕰️ Commits

- 6969289 feat: add write-only database connection details
- b3d8b5c fix: address write-only database details review